### PR TITLE
Persist preprocessing data for reliable weather forecasts

### DIFF
--- a/weather_station/server_weather_processing.py
+++ b/weather_station/server_weather_processing.py
@@ -706,16 +706,19 @@ def generate_daily_gif_with_plot(image_dir, output_gif, data):
 
 
 def compute_ECI(data):
-    """
-    Compute Environmental Comfort Index (ECI) from weather DataFrame.
-    Assumes columns:
-        - 'Humidity' (%)
-        - 'Median_Temperature_C' (°C)
-        - 'BMP_Pressure_hPa' (hPa)
-        - 'BH1750_Light_lx' (lux)
-    
+    """Compute Environmental Comfort Index (ECI) from a weather DataFrame.
+
+    The function is tolerant of differing humidity column names used by
+    various data sources.  It will look for a column named ``"Humidity"`` and
+    fall back to ``"DHT_Humidity_percent"`` if necessary.  The remaining
+    required columns are:
+
+    - ``"Median_Temperature_C"`` (°C)
+    - ``"BMP_Pressure_hPa"`` (hPa)
+    - ``"BH1750_Light_lx"`` (lux)
+
     Returns:
-        - pd.Series of ECI values (0–1), smoothed
+        pd.Series: Smoothed ECI values in the range 0–1.
     """
 
     def comfort_score(x, center, width, skew=0.0, kurtosis=1.0):
@@ -723,8 +726,13 @@ def compute_ECI(data):
         score = np.exp(-((x_shifted - center) / width) ** (2 * kurtosis))
         return np.clip(score, 0, 1)
 
+    # Determine which humidity column is available
+    humidity_col = "Humidity" if "Humidity" in data.columns else "DHT_Humidity_percent"
+    if humidity_col not in data.columns:
+        raise KeyError("Data must contain 'Humidity' or 'DHT_Humidity_percent' column")
+
     # Compute normalized comfort scores
-    H_norm = comfort_score(data["Humidity"], center=50, width=20, skew=0.2, kurtosis=1.2)
+    H_norm = comfort_score(data[humidity_col], center=50, width=20, skew=0.2, kurtosis=1.2)
     T_norm = comfort_score(data["Median_Temperature_C"], center=21, width=5, skew=0.5, kurtosis=1.0)
     P_norm = comfort_score(data["BMP_Pressure_hPa"], center=1013, width=10, skew=0.0, kurtosis=1.5)
     L_norm = comfort_score(data["BH1750_Light_lx"], center=8000, width=7000, skew=-0.2, kurtosis=0.8)

--- a/weather_station/weather_forcast.py
+++ b/weather_station/weather_forcast.py
@@ -349,6 +349,13 @@ class WeatherForecaster:
 
     def save_model(self, model_path):
         """Save the model and optimizer state to a file."""
+        # Persist both the network weights and any preprocessing information
+        # required to make meaningful predictions later.  Without these values
+        # the model can be loaded but the scaling applied during inference will
+        # not match the scaling the model was trained with, resulting in wildly
+        # inaccurate forecasts.  Keeping the scalers alongside the weights
+        # ensures that a restored model behaves consistently with a freshly
+        # trained one.
         torch.save({
             'model_state_dict': self.model.state_dict(),
             'optimizer_state_dict': self.optimizer.state_dict(),
@@ -356,7 +363,15 @@ class WeatherForecaster:
             'hidden_dim': self.hidden_dim,
             'output_dim': self.output_dim,
             'num_layers': self.num_layers,
-            'learning_rate': self.learning_rate
+            'learning_rate': self.learning_rate,
+            # Store sequence length and feature scaling parameters for later
+            'seq_length': self.seq_length,
+            'temp_min': getattr(self, 'temp_min', None),
+            'temp_max': getattr(self, 'temp_max', None),
+            'hum_min': getattr(self, 'hum_min', None),
+            'hum_max': getattr(self, 'hum_max', None),
+            'pres_min': getattr(self, 'pres_min', None),
+            'pres_max': getattr(self, 'pres_max', None),
         }, model_path)
         print(f"Model saved to {model_path}")
 
@@ -364,14 +379,26 @@ class WeatherForecaster:
         """
         Load the model and optimizer state from a file.
         """
-        checkpoint = torch.load(model_path, map_location=self.device, weights_only=True)
+        # ``weights_only`` is only available in newer versions of PyTorch and
+        # causes a ``TypeError`` on older installations.  Since we are loading
+        # a trusted checkpoint created by ``save_model`` above, the safer option
+        # is to omit that flag entirely for maximum compatibility.
+        checkpoint = torch.load(model_path, map_location=self.device)
         self.model.load_state_dict(checkpoint['model_state_dict'])
         self.optimizer.load_state_dict(checkpoint['optimizer_state_dict'])
-        self.input_dim = checkpoint['input_dim']
-        self.hidden_dim = checkpoint['hidden_dim']
-        self.output_dim = checkpoint['output_dim']
-        self.num_layers = checkpoint['num_layers']
-        self.learning_rate = checkpoint['learning_rate']
+        self.input_dim = checkpoint.get('input_dim', self.input_dim)
+        self.hidden_dim = checkpoint.get('hidden_dim', self.hidden_dim)
+        self.output_dim = checkpoint.get('output_dim', self.output_dim)
+        self.num_layers = checkpoint.get('num_layers', self.num_layers)
+        self.learning_rate = checkpoint.get('learning_rate', self.learning_rate)
+        # Restore sequence length and scaling parameters if present.
+        self.seq_length = checkpoint.get('seq_length', self.seq_length)
+        self.temp_min = checkpoint.get('temp_min', getattr(self, 'temp_min', 0))
+        self.temp_max = checkpoint.get('temp_max', getattr(self, 'temp_max', 1))
+        self.hum_min = checkpoint.get('hum_min', getattr(self, 'hum_min', 0))
+        self.hum_max = checkpoint.get('hum_max', getattr(self, 'hum_max', 1))
+        self.pres_min = checkpoint.get('pres_min', getattr(self, 'pres_min', 0))
+        self.pres_max = checkpoint.get('pres_max', getattr(self, 'pres_max', 1))
         print(f"Model loaded from {model_path}")
 
     class SequenceDataset(torch.utils.data.Dataset):


### PR DESCRIPTION
## Summary
- Save LSTM sequence length and feature scaling parameters alongside model weights
- Restore scaling values when loading a model and remove unsupported `weights_only` flag
- Tolerate alternate humidity column names when computing the Environmental Comfort Index

## Testing
- `python -m py_compile weather_station/server_weather_processing.py weather_station/weather_forcast.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6699ceb008321a1c318be1925ad23